### PR TITLE
Fix ESP tab ImGui EndTable scope error

### DIFF
--- a/Amalgam/src/Features/ImGui/Menu/Menu.cpp
+++ b/Amalgam/src/Features/ImGui/Menu/Menu.cpp
@@ -678,6 +678,7 @@ void CMenu::MenuVisuals(int iTab)
 				} EndSection();
 			}
 			EndTable();
+			break;
 
 			/*
 			// esp groups system i may or may not go through with. not sure what would be best though with ui/user experience


### PR DESCRIPTION
Fixed the missing break statement in ESP case of the menu switch:

Issue: Opening ESP tab caused ImGui error:
- "EndTable() call should only be done while in BeginTable() scope!"
- Error occurred due to missing break statement in ESP case (case 0)

Root Cause: Missing break statement after EndTable() call caused control flow to continue to next case
- This created nested or mismatched ImGui table scopes
- The "Page_8186CD93" error indicated ImGui internal page scoping issues

Fix: Added missing break statement after ESP case EndTable()
- Ensures proper control flow in switch statement
- Prevents table scope contamination between cases

The ESP tab should now open without ImGui errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)